### PR TITLE
feature(utils): Add BindAction and Payload utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "husky": "^1.1.1",
     "jest": "^23.6.0",
     "np": "^3.0.4",
-    "prettier": "^1.14.3",
+    "prettier": "^1.17.0",
     "pretty-quick": "^1.7.0",
     "ts-jest": "^23.10.4",
     "typescript": "^3.1.1"

--- a/readme.md
+++ b/readme.md
@@ -82,6 +82,55 @@ const reducer = handleActions<State, ActionTypes, Actions>(
 export default reducer;
 ```
 
+### Type utils
+
+`safe-redux` also provides some type utils to work with Redux.
+
+#### `BindAction`
+
+Changes the return type of an action creator to `void`. In the context of a
+component the only important part of an action is the types of it's arguments.
+We don't rely on the return type.
+
+```typescript
+// src/pages/MyPage/actions.ts
+
+import { ActionsUnion, createAction } from '@housinganywhere/safe-redux';
+
+export const INC = '[counter] increment';
+export const DEC = '[counter] decrement';
+export const INC_BY = '[counter] increment_BY';
+
+export const Actions = {
+  incBy: (by: number) => createAction(INC_BY, { by }),
+};
+
+export type Actions = ActionsUnion<typeof Actions>;
+
+// src/pages/MyPage/MyPage.container.ts
+
+import { connect } from 'react-redux';
+import { BindAction } from '@housinganywhere/safe-redux';
+
+import { Actions } from './actions';
+import MyPage from './MyPage';
+
+interface StateProps {
+  count: number;
+}
+
+interface DispatchProps {
+  incBy: BindAction<typeof Actions.incBy>; // (arg: number) => void
+}
+
+type MyPageProps = StateProps & DispatchProps;
+
+export default connect<StateProps, DispatchProps>(
+  (s) => ({ count: s.count }),
+  { incBy: Actions.incBy },
+)(MyPage);
+```
+
 ## Differences with `rex-tils`
 
 - Actions created by `createAction` are compliant with
@@ -91,4 +140,5 @@ export default reducer;
 - Added `handleActions` to create type safe reducers.
 - Smaller API. `safe-redux` only exports a few functions and types:
   - Functions: `createAction` and `handleActions`.
-  - Types: `Action`, `ActionsUnion` and `ActionsOfType`.
+  - Types: `Action`, `ActionsUnion`, `ActionsOfType`, `Payload` and
+    `BindAction`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,5 @@
-// tslint:disable-next-line no-any
-type AnyFunction = (...args: any[]) => any;
-interface StringMap<T> {
-  [key: string]: T;
-}
+export { BindAction } from './utils';
+import { AnyFunction, StringMap } from './utils';
 
 // We use conditional types so we can have only one type for defining Action
 export type Action<
@@ -14,8 +11,8 @@ export type Action<
     ? Readonly<{ type: T; error: boolean }>
     : Readonly<{ type: T; meta: M; error: boolean }>
   : M extends void
-    ? Readonly<{ type: T; payload: P; error: boolean }>
-    : Readonly<{ type: T; payload: P; meta: M; error: boolean }>;
+  ? Readonly<{ type: T; payload: P; error: boolean }>
+  : Readonly<{ type: T; payload: P; meta: M; error: boolean }>;
 
 export type ActionsUnion<A extends StringMap<AnyFunction>> = ReturnType<
   A[keyof A]
@@ -47,8 +44,8 @@ export function createAction<T extends string, P, M>(
       ? { type, error: false }
       : { type, meta, error: false }
     : meta === undefined
-      ? { type, payload, error: payload instanceof Error }
-      : { type, payload, meta, error: payload instanceof Error };
+    ? { type, payload, error: payload instanceof Error }
+    : { type, payload, meta, error: payload instanceof Error };
 }
 
 export function handleActions<

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,98 @@
+// tslint:disable no-any
+type ChangeReturnType<F, R> = F extends () => any
+  ? () => R
+  : F extends (arg: infer A) => any
+  ? (arg: A) => R
+  : F extends (arg1: infer A, arg2: infer B) => any
+  ? (arg1: A, arg2: B) => R
+  : F extends (arg1: infer A, arg2: infer B, arg3: infer C) => any
+  ? (arg1: A, arg2: B, arg3: C) => R
+  : F extends (
+      arg1: infer A,
+      arg2: infer B,
+      arg3: infer C,
+      arg4: infer D,
+    ) => any
+  ? (arg1: A, arg2: B, arg3: C, arg4: D) => R
+  : F extends (
+      arg1: infer A,
+      arg2: infer B,
+      arg3: infer C,
+      arg4: infer D,
+      arg5: infer E,
+    ) => any
+  ? (arg1: A, arg2: B, arg3: C, arg4: E, arg5: D) => R
+  : F extends (
+      arg1: infer A,
+      arg2: infer B,
+      arg3: infer C,
+      arg4: infer D,
+      arg5: infer E,
+      arg6: infer F,
+    ) => any
+  ? (arg1: A, arg2: B, arg3: C, arg4: D, arg5: E, arg6: F) => R
+  : F extends (
+      arg1: infer A,
+      arg2: infer B,
+      arg3: infer C,
+      arg4: infer D,
+      arg5: infer E,
+      arg6: infer F,
+      arg7: infer G,
+    ) => any
+  ? (arg1: A, arg2: B, arg3: C, arg4: D, arg5: E, arg6: F, arg7: G) => R
+  : F extends (
+      arg1: infer A,
+      arg2: infer B,
+      arg3: infer C,
+      arg4: infer D,
+      arg5: infer E,
+      arg6: infer F,
+      arg7: infer G,
+      arg8: infer H,
+    ) => any
+  ? (
+      arg1: A,
+      arg2: B,
+      arg3: C,
+      arg4: D,
+      arg5: E,
+      arg6: F,
+      arg7: G,
+      arg8: H,
+    ) => R
+  : F extends (
+      arg1: infer A,
+      arg2: infer B,
+      arg3: infer C,
+      arg4: infer D,
+      arg5: infer E,
+      arg6: infer F,
+      arg7: infer G,
+      arg8: infer H,
+      arg9: infer I,
+    ) => any
+  ? (
+      arg1: A,
+      arg2: B,
+      arg3: C,
+      arg4: D,
+      arg5: E,
+      arg6: F,
+      arg7: G,
+      arg8: H,
+      arg9: I,
+    ) => R
+  : never;
+
+export type AnyFunction = (...args: any[]) => any;
+
+// tslint:enable no-any
+
+// use case example:
+// @link http://bit.ly/2KSnhEK
+export type BindAction<A> = ChangeReturnType<A, void>;
+
+export interface StringMap<T> {
+  [key: string]: T;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3494,10 +3494,10 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
-prettier@^1.14.3:
-  version "1.14.3"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.3.tgz#90238dd4c0684b7edce5f83b0fb7328e48bd0895"
-  integrity sha512-qZDVnCrnpsRJJq5nSsiHCE3BYMED2OtsI+cmzIzF1QIfqm5ALf8tEJcO27zV1gKNKRPdhjO0dNWnrzssDQ1tFg==
+prettier@^1.17.0:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.17.0.tgz#53b303676eed22cc14a9f0cec09b477b3026c008"
+  integrity sha512-sXe5lSt2WQlCbydGETgfm1YBShgOX4HxQkFPvbxkcwgDvGDeqVau8h+12+lmSVlP3rHPz0oavfddSZg/q+Szjw==
 
 pretty-format@^23.6.0:
   version "23.6.0"


### PR DESCRIPTION
Add type utils:

- `BindAction`: changes return type of an action creator to `void`. It's the type that should be passed to a component where we don't care about what dispatching an action returns just what arguments we need to call it with.
- `Payload`: get the payload of the action created by an action creator.

Also update prettier to latest version.