### PR TITLE
feature(types): Add Handler type

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -55,7 +55,7 @@ Handle the actions:
 ```ts
 // src/pages/MyPage/reducer.ts
 
-import { handleActions } from '@housinganywhere/safe-redux';
+import { handleActions, Handler } from '@housinganywhere/safe-redux';
 
 import { User } from '../types';
 
@@ -69,11 +69,17 @@ const initialState: State = {
   count: 0,
 };
 
+// `Handler` type can be used when you don't want to define the handlers inline
+const handleIncBy: Handler<State, typeof INC_BY, Actions> = (
+  { count },
+  { payload },
+) => ({ count: count + payload });
+
 const reducer = handleActions<State, ActionTypes, Actions>(
   {
     [INC]: ({ count }) => ({ count: count + 1 }),
     [DEC]: ({ count }) => ({ count: count - 1 }),
-    [INC_BY]: ({ count }, { payload }) => ({ count: count + payload }),
+    [INC_BY]: handleIncBy,
     [WITH_META]: ({ count }, { payload }) => ({ count: count + payload }),
   },
   initialState,
@@ -140,4 +146,5 @@ export default connect<StateProps, DispatchProps>(
 - Added `handleActions` to create type safe reducers.
 - Smaller API. `safe-redux` only exports a few functions and types:
   - Functions: `createAction` and `handleActions`.
-  - Types: `Action`, `ActionsUnion`, `ActionsOfType` and `BindAction`.
+  - Types: `Action`, `ActionsUnion`, `ActionsOfType`, `Handler` and
+    `BindAction`.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -85,14 +85,15 @@ type ChangeReturnType<F, R> = F extends () => any
     ) => R
   : never;
 
-export type AnyFunction = (...args: any[]) => any;
+// TS `ReturnType` defaults to `any` instead of `never`
+export type ReturnType<T extends (...args: any[]) => any> = T extends (
+  ...args: any[]
+) => infer R
+  ? R
+  : never;
 
 // tslint:enable no-any
 
 // use case example:
 // @link http://bit.ly/2KSnhEK
 export type BindAction<A> = ChangeReturnType<A, void>;
-
-export interface StringMap<T> {
-  [key: string]: T;
-}


### PR DESCRIPTION
> `Handler` type can be used when you don't want to define the handlers inline